### PR TITLE
Add int64 and uint64 to supported nifti datatypes

### DIFF
--- a/fsleyes_preset.py
+++ b/fsleyes_preset.py
@@ -110,7 +110,7 @@ set_name = {'fdt_paths.nii.gz': 'fdt_paths.nii.gz',
             }
 
 # List of supported nifti datatypes
-supported_data_types = ['int8', 'int16', 'int32', 'float32', 'float64', 'uint8', 'uint16']
+supported_data_types = ['int8', 'int16', 'int32', 'int64', 'float32', 'float64', 'uint8', 'uint16', 'uint64']
 
 
 def run_command(command, print_command=True):


### PR DESCRIPTION
## Summary

INT64 (NIfTI datatype 1024) and UINT64 masks were being skipped with a warning, e.g.:

```console
$ ff sub-amu01_dwi.nii.gz sub-amu01_dwi_dwi_mean_centerline.nii.gz sub-amu01_rec-average_dwi_label-SC_seg.nii.gz mask_sub-amu01_dwi_dwi_mean.nii.gz
WARNING - Unsupported datatype for mask_sub-amu01_dwi_dwi_mean.nii.gz
```

FSLeyes handles these datatypes fine, so adding them to `supported_data_types` lets the masks pass through.